### PR TITLE
chore: align VS Code configuration with Rstack

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["rstack.rstack"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "compile-hero.config": null
+  "compile-hero.config": null,
+  "search.useIgnoreFiles": true,
+  "editor.defaultFormatter": "rstack.rstack"
 }


### PR DESCRIPTION
VS Code does not use Rstack as the repository-wide default formatter. Align the shared editor settings with rsbuild-plugin-template. Recommend the Rstack extension alongside the formatter setting.